### PR TITLE
add a script for running exo in a virtual python 3.12 venv

### DIFF
--- a/run_exo.sh
+++ b/run_exo.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+uv venv --python=3.12
+source .venv/bin/activate
+uv pip install -e .
+exo


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Adds a script to run exo in a virtual python 3.12 environment.